### PR TITLE
"Changed the way the script builds the output variable according with…

### DIFF
--- a/config/objects/nInput_CBPMRunningFlows.js
+++ b/config/objects/nInput_CBPMRunningFlows.js
@@ -83,59 +83,24 @@ nInput_CBPMRunningFlows.prototype.input = function(scope, args) {
                 if (isDef(instances) && isArray(instances)) {
                 	$from(instances).select((t) => {
                         if (ow.format.dateDiff.inHours(ow.format.fromWeDoDateToDate(t.instanceStartTime)) <= this.hoursToCheck) {
-                        	switch (t.instanceStatus) {
-                            	case 'FINISHED':
-                                	oo.push({
-                                    	Category: r.flowCategory,
-                                        Flow: r.flowName,
-                                        Version: t.instanceVersion,
-                                        "Run ID": t.instanceId,
-                                        User: t.instanceStartUser,
-                                        "Status": t.instanceStatus,
-                                        "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
-                                        "End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime)
-                                    });
-                                    break;
-                                case 'ERROR':
-                                	oo.push({
-                                    	Category: r.flowCategory,
-                                        Flow: r.flowName,
-                                        Version: t.instanceVersion,
-                                        "Run ID": t.instanceId,
-                                        User: t.instanceStartUser,
-                                        "Status": t.instanceStatus,
-                                        "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
-                                        "End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime),
-                                        Exception: t.instanceErrorMessage
-                                    });
-                                    break;
-                                case 'STARTED':
-                                	oo.push({
-                                    	Category: r.flowCategory,
-                                        Flow: r.flowName,
-                                        Version: t.instanceVersion,
-                                        "Run ID": t.instanceId,
-                                        User: t.instanceStartUser,
-                                        "Status": t.instanceStatus,
-                                        "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime)
-                                    });
-                                    break;
-								default:
-                                	oo.push({
-                                    	Category: r.flowCategory,
-                                        Flow: r.flowName,
-                                        Version: t.instanceVersion,
-                                        "Run ID": t.instanceId,
-                                        User: t.instanceStartUser,
-                                        "Status": t.instanceStatus,
-                                        "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
-                                        "End Date": (isUnDef(t.instanceEndTime)) ? "n/a" : ow.format.fromWeDoDateToDate(t.instanceEndTime)
-                                    });
-                            }
+                                var line = { Category: r.flowCategory, Flow: r.flowName, Version: t.instanceVersion, "Run ID": t.instanceId,
+                                User: t.instanceStartUser, "Status": t.instanceStatus, "Start Date":ow.format.fromWeDoDateToDate(t.instanceStartTime)};
+
+                                switch (t.instanceStatus) {
+                                        case 'ERROR':
+                                                if (isDef(t.instanceErrorMessage) && isDef(t.instanceEndTime)) {
+                                                        line = merge(line, { "End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime), "Exception": t.instanceErrorMessage});
+                                                }
+                                                break;
+                                        default:
+                                                if (isDef((t.instanceEndTime))) {
+                                                        line = merge(line, {"End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime)});
+                                                }
+                                }
+                                 oo.push(line);
                         }
                 	});
-        		}
-
+        	}
                 return oo;
     
             //});

--- a/config/objects/nInput_CBPMRunningFlows.js
+++ b/config/objects/nInput_CBPMRunningFlows.js
@@ -88,16 +88,16 @@ nInput_CBPMRunningFlows.prototype.input = function(scope, args) {
 
                                 switch (t.instanceStatus) {
                                         case 'ERROR':
-                                                if (isDef(t.instanceErrorMessage) && isDef(t.instanceEndTime)) {
-                                                        line = merge(line, { "End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime), "Exception": t.instanceErrorMessage});
-                                                }
+                                                line = merge(line, { "End Date": (isUnDef(t.instanceEndTime)) ? "n/a" : ow.format.fromWeDoDateToDate(t.instanceEndTime), "Exception": (isUnDef(t.instanceErrorMessage)) ? "n/a" : t.instanceErrorMessage});
+                                                break;
+                                        case 'STARTED':
                                                 break;
                                         default:
                                                 if (isDef((t.instanceEndTime))) {
                                                         line = merge(line, {"End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime)});
                                                 }
                                 }
-                                 oo.push(line);
+                                oo.push(line);
                         }
                 	});
         	}

--- a/config/objects/nInput_CBPMRunningFlows.js
+++ b/config/objects/nInput_CBPMRunningFlows.js
@@ -79,23 +79,59 @@ nInput_CBPMRunningFlows.prototype.input = function(scope, args) {
                         if (!String(e).match(/Cannot find the object/)) logErr("Can't retrieve instances, in " + aKey + ", for flow: " + r.flowName + " -- " + String(e));
                     }
                 });
-    
-                if (isDef(instances) && isArray(instances)) {          
-                    $from(instances).select((t) => {
+
+                if (isDef(instances) && isArray(instances)) {
+                	$from(instances).select((t) => {
                         if (ow.format.dateDiff.inHours(ow.format.fromWeDoDateToDate(t.instanceStartTime)) <= this.hoursToCheck) {
-                            oo.push({
-                                Category: r.flowCategory,
-                                Flow: r.flowName,
-                                Version: t.instanceVersion,
-                                "Run ID": t.instanceId,
-                                User: t.instanceStartUser,
-                                "Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
-                                Exception: t.instanceErrorMessage
-                            });
+                        	switch (t.instanceStatus) {
+                            	case 'FINISHED':
+                                	oo.push({
+                                    	Category: r.flowCategory,
+                                        Flow: r.flowName,
+                                        Version: t.instanceVersion,
+                                        "Run ID": t.instanceId,
+                                        User: t.instanceStartUser,
+                                        "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
+                                        "End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime)
+                                    });
+                                    break;
+                                case 'ERROR':
+                                	oo.push({
+                                    	Category: r.flowCategory,
+                                        Flow: r.flowName,
+                                        Version: t.instanceVersion,
+                                        "Run ID": t.instanceId,
+                                        User: t.instanceStartUser,
+                                        "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
+                                        "End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime),
+                                        Exception: t.instanceErrorMessage
+                                    });
+                                    break;
+                                case 'STARTED':
+                                	oo.push({
+                                    	Category: r.flowCategory,
+                                        Flow: r.flowName,
+                                        Version: t.instanceVersion,
+                                        "Run ID": t.instanceId,
+                                        User: t.instanceStartUser,
+                                        "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime)
+                                    });
+                                    break;
+								default:
+                                	oo.push({
+                                    	Category: r.flowCategory,
+                                        Flow: r.flowName,
+                                        Version: t.instanceVersion,
+                                        "Run ID": t.instanceId,
+                                        User: t.instanceStartUser,
+                                        "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
+                                        "End Date": (isUnDef(t.instanceEndTime)) ? "n/a" : ow.format.fromWeDoDateToDate(t.instanceEndTime)
+                                    });
+                            }
                         }
-                    });
-                }
-    
+                	});
+        		}
+
                 return oo;
     
             //});

--- a/config/objects/nInput_CBPMRunningFlows.js
+++ b/config/objects/nInput_CBPMRunningFlows.js
@@ -91,6 +91,7 @@ nInput_CBPMRunningFlows.prototype.input = function(scope, args) {
                                         Version: t.instanceVersion,
                                         "Run ID": t.instanceId,
                                         User: t.instanceStartUser,
+                                        "Status": t.instanceStatus,
                                         "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
                                         "End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime)
                                     });
@@ -102,6 +103,7 @@ nInput_CBPMRunningFlows.prototype.input = function(scope, args) {
                                         Version: t.instanceVersion,
                                         "Run ID": t.instanceId,
                                         User: t.instanceStartUser,
+                                        "Status": t.instanceStatus,
                                         "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
                                         "End Date": ow.format.fromWeDoDateToDate(t.instanceEndTime),
                                         Exception: t.instanceErrorMessage
@@ -114,6 +116,7 @@ nInput_CBPMRunningFlows.prototype.input = function(scope, args) {
                                         Version: t.instanceVersion,
                                         "Run ID": t.instanceId,
                                         User: t.instanceStartUser,
+                                        "Status": t.instanceStatus,
                                         "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime)
                                     });
                                     break;
@@ -124,6 +127,7 @@ nInput_CBPMRunningFlows.prototype.input = function(scope, args) {
                                         Version: t.instanceVersion,
                                         "Run ID": t.instanceId,
                                         User: t.instanceStartUser,
+                                        "Status": t.instanceStatus,
                                         "Start Date": ow.format.fromWeDoDateToDate(t.instanceStartTime),
                                         "End Date": (isUnDef(t.instanceEndTime)) ? "n/a" : ow.format.fromWeDoDateToDate(t.instanceEndTime)
                                     });


### PR DESCRIPTION
This change aims to correct the way the script builds the output variable according with the "flow status" passed as argument. Considering the "flow status", the script passes only the intended arguments into the output variable. For example, when listing the running flows it doesn't make sense to show the "Exception" column in the frontend page, because we won't have a value for it in this specific context. The same applies to some other "flow status" scenarios. Please, review this change and let me know wether you agree or not with it.