### PR TITLE
fix #209

### DIFF
--- a/config/inputs.disabled/yaml/03.db.errorflows.yaml
+++ b/config/inputs.disabled/yaml/03.db.errorflows.yaml
@@ -31,7 +31,7 @@ input:
          
          postgresql:
             Database/In Error Flows        : >
-               SELECT INSTANCE_ID "Instance", C."SHORT_NAME" "Flow", A."FLOW_VERSION" "Version", A."FLOW_RUN_ID" "RunID", A."CREATED_BY" "User", 
+               SELECT "INSTANCE_ID" "Instance", C."SHORT_NAME" "Flow", A."FLOW_VERSION" "Version", A."FLOW_RUN_ID" "RunID", A."CREATED_BY" "User", 
                   CASE WHEN A."FLOW_STATUS" = 3 
                   then 'Error' 
                   ELSE 'Completed' 


### PR DESCRIPTION
fix #209: Input Disabled 03.db.errorflows.yaml error in postgres "instance_id does not exist" The query has the column INSTANCE_ID without " and the column needs to be referenced by double quotes.