### PR TITLE
#216

### DIFF
--- a/config/objects/nOutput_SNMPServer.js
+++ b/config/objects/nOutput_SNMPServer.js
@@ -170,7 +170,12 @@ nOutput_SNMPServer.prototype.sendTrap = function (argsValue, params, snmpProtoco
         var response = this.entitiesExtraction(argsValue, IDMapping)
         log(stringify(response.trapArr))
         //snmp.trap(params.snmpBaseOID, response.trapArr)
-        snmp.trap(params.snmpBaseOID, params.sysUpTime, response.trapArr)
+        if (getVersion() > "20231221") {
+            snmp.trap(params.snmpBaseOID, params.sysUpTime, response.trapArr)
+         } else {
+            logWarn("nOutput_SNMPServer | sysUpTime functionality is not available on the current version " + getVersion() + ". Please upgrade to a more recent version.")
+            snmp.trap(params.snmpBaseOID, response.trapArr)
+         }
         log("Trap Sent Successfully")
     }
     catch (e) {

--- a/config/objects/nOutput_SNMPServer.js
+++ b/config/objects/nOutput_SNMPServer.js
@@ -36,7 +36,6 @@ var nOutput_SNMPServer = function (aMap) {
     if (isUnDef(aMap.snmpSecurityName) || aMap.snmpSecurityName === null) aMap.snmpSecurityName = "NMS";
     if (isUnDef(aMap.timeOut) || aMap.timeOut === null) aMap.timeOut = 5000;
     if (isUnDef(aMap.numOfRetries) || aMap.timeOut === null) aMap.numOfRetries = 3;
-    if (isUnDef(aMap.snmpSecurityName) || aMap.snmpSecurityName === null) aMap.snmpSecurityName = "NMS";
 
     this.IDMapping = aMap.oidMapping
     this.params = {

--- a/config/objects/nOutput_SNMPServer.js
+++ b/config/objects/nOutput_SNMPServer.js
@@ -1,5 +1,6 @@
 /** 
- * Author: Surya Kalyan Jaddu
+ * Author: Surya Kalyan Jaddu 
+ * Changes: Andreia Brizida
  * 
  * <odoc>
  * <key>nAttrmon.nOutput_SNMPServer(aMap)</key>
@@ -9,6 +10,7 @@
  *    - baseOID((string) Base Oid is used to send traps.\
  *    - snmpVersion(string) it defines version of SNMP server.\
  *    - oidMapping(Map) it contains keys mapped with OID values to send traps.\
+ *    - sysUpTime(double) it defines how long ago in milliseconds the trap occurred.\
  *
  * </odoc>
  */
@@ -23,6 +25,7 @@ var nOutput_SNMPServer = function (aMap) {
     baseOID = _$(aMap.baseOID, "var aMap.baseOID").isString().regexp(/([0-9]{1,4}\.)/).$_("something")
     snmpVersion = _$(aMap.snmpVersion, "snmpVersion").oneOf([1, 2, 3]).isNumber().default(2)
     oidMapping = _$(aMap.oidMapping, "oidMapping").isObject().$_("Please Map the oid's")
+    sysUpTime = _$(aMap.sysUpTime, "var aMap.sysUpTime").isDouble().default(0)
 
     snmpAuthPassPhrase = _$(aMap.snmpAuthPassPhrase, "snmpAuthPassPhrase").isString().$_("Please provide snmpAuthPhrase")
     snmpPrivPassPhrase = _$(aMap.snmpPrivPassPhrase, "snmpPrivPassPhrase").isString().$_("Please Provoide snmpPrivPassPhrase")
@@ -33,6 +36,7 @@ var nOutput_SNMPServer = function (aMap) {
     if (isUnDef(aMap.snmpSecurityName) || aMap.snmpSecurityName === null) aMap.snmpSecurityName = "NMS";
     if (isUnDef(aMap.timeOut) || aMap.timeOut === null) aMap.timeOut = 5000;
     if (isUnDef(aMap.numOfRetries) || aMap.timeOut === null) aMap.numOfRetries = 3;
+    if (isUnDef(aMap.snmpSecurityName) || aMap.snmpSecurityName === null) aMap.snmpSecurityName = "NMS";
 
     this.IDMapping = aMap.oidMapping
     this.params = {
@@ -42,7 +46,8 @@ var nOutput_SNMPServer = function (aMap) {
         "numOfRetries": aMap.numOfRetries,
         "snmpVersion": snmpVersion,
         "snmpEngineID": snmpEngineID,
-        "snmpBaseOID": baseOID
+        "snmpBaseOID": baseOID,
+        "sysUpTime": sysUpTime
     }
 
     this.snmpProtocols = {
@@ -165,7 +170,8 @@ nOutput_SNMPServer.prototype.sendTrap = function (argsValue, params, snmpProtoco
         if (params.snmpVersion <= 2) var snmp = new SNMP(params.snmpIPAddress, params.snmpCommunity); else var snmp = new SNMP(params.snmpIPAddress, params.snmpCommunity, params.snmpTimeout, params.numOfRetries, params.snmpVersion, snmpProtocols);
         var response = this.entitiesExtraction(argsValue, IDMapping)
         log(stringify(response.trapArr))
-        snmp.trap(params.snmpBaseOID, response.trapArr)
+        //snmp.trap(params.snmpBaseOID, response.trapArr)
+        snmp.trap(params.snmpBaseOID, params.sysUpTime, response.trapArr)
         log("Trap Sent Successfully")
     }
     catch (e) {

--- a/config/outputs.disabled/yaml/10.SNMPServer_Output.yaml
+++ b/config/outputs.disabled/yaml/10.SNMPServer_Output.yaml
@@ -19,4 +19,5 @@ output:
     snmpAuthProtocol: "MD5"
     snmpPrivProtocol: "AES128"
     snmpSecurityName: "NMS"
+    sysUpTime: 0
 


### PR DESCRIPTION
 nOutput_SNMPServer add sysUpTime defining how long ago in milliseconds the trap occurred

After the change done in SNMP Lib there is the need to enable in the corresponding object nOutput_SNMPServer the ability to define sysUpTime. This parameter defines how long ago in milliseconds the trap occurred and it's used when integrating with OpenNMS.