### PR TITLE
Add extra memory details to nInput_RAIDMemory.js

### DIFF
--- a/.package.yaml
+++ b/.package.yaml
@@ -19,7 +19,7 @@ name: nAttrMon
 main: nattrmon.js
 mainJob: ''
 license: Apache 2.0 license
-version: '20240312'
+version: '20240325'
 dependencies:
   openaf: '>=20230704'
 files:

--- a/config/inputs.disabled/yaml/09.memory.yaml
+++ b/config/inputs.disabled/yaml/09.memory.yaml
@@ -5,4 +5,5 @@ input:
    onlyOnEvent  : true
    execFrom     : nInput_RAIDMemory
    execArgs     : 
-      chKeys      : raidServers
+      chKeys            : raidServers
+      #extraMemoryDetails: true

--- a/config/objects/nInput_RAIDMemory.js
+++ b/config/objects/nInput_RAIDMemory.js
@@ -31,7 +31,7 @@ var nInput_RAIDMemory = function(anMonitoredAFObjectKey, attributePrefix) {
 	
 		this.params.extraMemoryDetails = _$(this.params.extraMemoryDetails).isBoolean().default(false)
 		if (this.params.extraMemoryDetails) {
-			this._args = { ShowMemoryDetails: true }
+			this._args = { ShowMemoryDetails: true }
 		} else {
 			this._args = { }
 		}


### PR DESCRIPTION
On newer RAID/WAF versions the StatusReport operation can also retrieve information regarding the current Java GC collectors and spaces to provide better insights on GC behaviour.

Adding the flag _extraMemoryDetails_ to nInput_RAIDMemory to include these details on compatible versions.