### PR TITLE
chore: Add support for loading external OpenAF libraries

### DIFF
--- a/lib/nmain.js
+++ b/lib/nmain.js
@@ -24,6 +24,7 @@ var __NAM_CHANNEL_LVALS             = __;
 var __NAM_CHANNEL_WARNS             = __;
 var __NAM_CHANNEL_WNOTS             = __
 var __NAM_CHANNEL_LOGS              = __
+var __NAM_LIBS                      = __
 var __NAM_JSONLOG                   = false;
 var __NAM_SLOWDOWN                  = true
 var __NAM_SLOWDOWN_WARNS            = false
@@ -81,6 +82,8 @@ if (isDef(pms.BUFFERBYTIME))   __NAM_BUFFERBYTIME = Number(pms.BUFFERBYTIME);
 
 if (isDef(pms.COREOBJECTS))    __NAM_COREOBJECTS = pms.COREOBJECTS;
 if (isDef(pms.COREOBJECTS_LAZYLOADING)) __NAM_COREOBJECTS_LAZYLOADING = toBoolean(pms.COREOBJECTS_LAZYLOADING);
+
+if (isString(pms.LIBS)) __NAM_LIBS = pms.LIBS
 
 if (isString(pms.CHANNEL_CVALS))  __NAM_CHANNEL_CVALS = pms.CHANNEL_CVALS;
 if (isString(pms.CHANNEL_LVALS))  __NAM_CHANNEL_LVALS = pms.CHANNEL_LVALS;
@@ -190,6 +193,23 @@ var nAttrMon = function(aConfigPath, debugFlag) {
 	
 		print(repeat(t.length, "-"));
 	})();
+
+	// If __NAM_LIBS is provided as a comma-delimited list of OpenAF libraries then try to load them
+	if (isString(__NAM_LIBS)) {
+		// Load external libs
+		__NAM_LIBS.split(",").forEach(lib => {
+			try {
+				// Ensure the lib name is trimmed
+				var _lib = lib.trim()
+				log(`Loading external lib '${_lib}'...`)
+				// Load the lib
+				loadLib(_lib)
+			} catch(e) {
+				// Log the error and continue
+				logErr(`Problem loading external lib '${_lib}': ${e}`)
+			}
+		})
+	}
 
 	this.chCurrentValues = "nattrmon::cvals";
 	this.chLastValues    = "nattrmon::lvals";

--- a/nattrmon.yaml.sample
+++ b/nattrmon.yaml.sample
@@ -62,3 +62,6 @@
 
 # Custom order of loading plugs
 #PLUGSORDER: "outputs,inputs,validations"
+
+# Pre-loading of external OpenAF libraries (useful for adding OpenAF channel types)
+#LIBS: "aws.js,s3.js"

--- a/oJob_nAttrMon.yaml
+++ b/oJob_nAttrMon.yaml
@@ -185,6 +185,8 @@ jobs:
     if (isDef(args.__NAM_SLOWDOWN_TIME))  global.__NAM_SLOWDOWN_TIME  = Number(args.__NAM_SLOWDOWN_TIME)
     if (isDef(args.__NAM_NOPLUGFILES))    global.__NAM_NOPLUGFILES    = Boolean(args.__NAM_NOPLUGFILES)
 
+    if (isString(args.__NAM_LIBS)) global.__NAM_LIBS = String(args.__NAM_LIBS)
+
     if (isString(args.__NAM_CHANNEL_CVALS))  global.__NAM_CHANNEL_CVALS = String(args.__NAM_CHANNEL_CVALS);
     if (isString(args.__NAM_CHANNEL_LVALS))  global.__NAM_CHANNEL_LVALS = String(args.__NAM_CHANNEL_LVALS);
     if (isString(args.__NAM_CHANNEL_WARNS))  global.__NAM_CHANNEL_WARNS = String(args.__NAM_CHANNEL_WARNS);


### PR DESCRIPTION
The code changes introduce support for loading external OpenAF libraries. The `__NAM_LIBS` variable is checked for a comma-delimited list of library names. Each library is then loaded using the `loadLib` function. If there is an error loading a library, it is logged and the loading process continues.