### PR TITLE
#235

### DIFF
--- a/config/objects/nOutput_SNMPServer.js
+++ b/config/objects/nOutput_SNMPServer.js
@@ -21,8 +21,6 @@ var nOutput_SNMPServer = function (aMap) {
 
     if (isUnDef(aMap.enabled) || aMap.enabled === null) aMap.enabled = true;
 
-    if (aMap.enabled == false) return;
-
     if (aMap.enabled == true) { 
         this.enabled = true
         snmpAddress = _$(aMap.snmpAddress, "var aMap.snmpAddress").regexp(/^udp:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{3}/).default("something")


### PR DESCRIPTION
Enabled the return of the object to prevent the error in log when enabled was false: {"@timestamp":"2025-01-13T10:27:49.094Z","level":"ERROR","message":"SNMP Output | TypeError: Cannot find function aFunction in object [object Object]."}